### PR TITLE
Fixed app icon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ CXXFILES	= $(notdir $(wildcard *.cxx))
 AFILES		= $(notdir $(wildcard *.s))
 
 IMAGES		= timedit.png
-OFILES		= $(addprefix build/,$(CPPFILES:.cpp=.o) $(CXXFILES:.cxx=.o) $(IMAGES:.png=.o))
+OFILES		= $(addprefix build/,$(CPPFILES:.cpp=.o) $(CXXFILES:.cxx=.o) $(AFILES:.s=.o) $(IMAGES:.png=.o))
 
-LIBS		= -lfreeimage -ltinyxml2 -lfltk_images -lfltk_png -lfltk_z -lfltk
+LIBS		= -lFreeImage -ltinyxml2 -lfltk_images -lfltk_png -lfltk_z -lfltk
 
 ifeq "$(CONF)" "debug"
 CFLAGS		= -g
@@ -28,7 +28,7 @@ ifeq "$(OS)" "Windows_NT"
 LIBS		+= -lcomctl32 -lcomdlg32 -lgdi32 -lole32 -luuid
 LIBDIRS		= -LC:\fltk-1.3.4-1\lib -LC:\tinyxml2 -LC:\freeimage
 INCLUDE		= -IC:\fltk-1.3.4-1 -IC:\tinyxml2 -IC:\freeimage
-CFLAGS		+= -DWIN32
+CFLAGS		+= -DWIN32 -fpermissive
 endif
 
 CC		= gcc
@@ -46,6 +46,10 @@ build/%.o: %.cpp
 	$(CXX) $(CXXFLAGS) $(INCLUDE) -c $< -o $@
 	
 build/%.o: %.cxx
+	@mkdir -p $(dir $@)
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -c $< -o $@
+	
+build/%.o: %.s
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) $(INCLUDE) -c $< -o $@
 

--- a/main.cpp
+++ b/main.cpp
@@ -1341,7 +1341,7 @@ void cb_About(Fl_Menu_ *w, void *u) {
 	fl_message("TIMedit - PSX TIM conversion/editing tool\nBy Lameguy64");
 }
 
-extern char binary_icons_timedit_png_start[];
+extern char png_timedit[];
 //extern unsigned int _binary_icons_timedit_png_size;
 
 int main(int argc, char** argv)
@@ -1360,7 +1360,7 @@ int main(int argc, char** argv)
 	ui = new MainUI;
 
 	app_icon = new Fl_PNG_Image( NULL, 
-		(unsigned char*)binary_icons_timedit_png_start, 
+		(unsigned char*)png_timedit, 
 		400);
 		
 	ui->icon( app_icon );


### PR DESCRIPTION
This pull request fixes the issue described in Issue #6 . 

In summary, the app fails to compile properly due to an undefined reference to `binary_icons_timedit_png_start`.

### Fix description
To fix this, the variable `binary_icons_timedit_png_start` in `main.cpp` has been renamed to `png_timedit`, as this is the name of the symbol defined in `data.s`, which includes the required app icon.

Furthermore, the Makefile has been changed to include this `data.s` file in the compilation process. 

EDIT 2024/06/08: the Makefile has been changed to include the `-fpermissive` flag in the `CFLAGS` variable, as compilation fails otherwise.

